### PR TITLE
feat: add configurable overlay parameters

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,10 @@
+{
+  "dotSize": 12,
+  "padding": [6, 10],
+  "margin": 24,
+  "position": "top-right",
+  "font": "600 11pt sans-serif",
+  "pulseScale": 1.06,
+  "listeningPeriod": 700,
+  "thinkingPeriod": 1100
+}

--- a/extension.js
+++ b/extension.js
@@ -6,6 +6,7 @@ import GLib from 'gi://GLib';
 import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta'; // на будущее
 import { Extension } from 'resource:///org/gnome/shell/extensions/extension.js';
+import * as ByteArray from 'resource:///org/gnome/gjs/modules/byteArray.js';
 
 const BUS_NAME = 'org.example.AIOverlay';
 const OBJ_PATH = '/org/example/AIOverlay';
@@ -21,8 +22,36 @@ const IFACE_XML = `
   </interface>
 </node>`;
 
+const DEFAULT_CONFIG = {
+  dotSize: 12,
+  padding: [6, 10],
+  margin: 24,
+  position: 'top-right',
+  font: '600 11pt sans-serif',
+  pulseScale: 1.06,
+  listeningPeriod: 700,
+  thinkingPeriod: 1100,
+};
+
+function loadConfig(dir) {
+  try {
+    const file = dir.get_child('config.json');
+    if (file?.query_exists(null)) {
+      const [ok, bytes] = file.load_contents(null);
+      if (ok) {
+        const cfg = JSON.parse(ByteArray.toString(bytes));
+        return { ...DEFAULT_CONFIG, ...cfg };
+      }
+    }
+  } catch (e) {
+    logError(e, '[ai-overlay] loadConfig');
+  }
+  return { ...DEFAULT_CONFIG };
+}
+
 class Overlay {
-  constructor() {
+  constructor(cfg) {
+    this._cfg = cfg;
     this._box = null; this._dot = null; this._label = null;
     this._pulse = 0; this._state = 'idle';
     this._monitorMgr = null; this._monitorsChangedId = 0;
@@ -61,9 +90,17 @@ class Overlay {
   }
 
   _build() {
+    const pad = Array.isArray(this._cfg.padding) ? `${this._cfg.padding[0]}px ${this._cfg.padding[1]}px` : `${this._cfg.padding}px`;
     this._box = new St.BoxLayout({ style_class: 'ai-overlay', reactive: false });
-    this._dot = new St.Widget({ style_class: 'ai-dot', width: 12, height: 12, reactive: false });
+    this._box.set_style(`padding:${pad};`);
+
+    const size = this._cfg.dotSize;
+    this._dot = new St.Widget({ style_class: 'ai-dot', reactive: false });
+    this._dot.set_style(`width:${size}px;height:${size}px;`);
+
     this._label = new St.Label({ text: '', style_class: 'ai-label', reactive: false });
+    this._label.set_style(`font:${this._cfg.font};`);
+
     this._box.add_child(this._dot); this._box.add_child(this._label);
     global.stage.add_child(this._box);
     this._box.hide();
@@ -79,10 +116,20 @@ class Overlay {
     const d = global.display;
     const idx = d.get_primary_monitor();
     const rect = d.get_monitor_geometry(idx);
-    const m = 24;
+    let mx, my;
+    if (Array.isArray(this._cfg.margin)) [mx, my] = this._cfg.margin; else mx = my = this._cfg.margin;
     GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
       if (!this._box) return GLib.SOURCE_REMOVE;
-      this._box.set_position(rect.x + rect.width - this._box.width - m, rect.y + m);
+      switch (this._cfg.position) {
+        case 'top-left':
+          this._box.set_position(rect.x + mx, rect.y + my); break;
+        case 'bottom-left':
+          this._box.set_position(rect.x + mx, rect.y + rect.height - this._box.height - my); break;
+        case 'bottom-right':
+          this._box.set_position(rect.x + rect.width - this._box.width - mx, rect.y + rect.height - this._box.height - my); break;
+        default:
+          this._box.set_position(rect.x + rect.width - this._box.width - mx, rect.y + my); break;
+      }
       return GLib.SOURCE_REMOVE;
     });
   }
@@ -98,7 +145,7 @@ class Overlay {
     const tick = () => {
       if (!this._box) return GLib.SOURCE_REMOVE;
       this._box.ease({
-        scale_x: 1.06, scale_y: 1.06, duration: half,
+        scale_x: this._cfg.pulseScale, scale_y: this._cfg.pulseScale, duration: half,
         mode: Clutter.AnimationMode.EASE_IN_OUT_QUAD,
         onComplete: () => this._box?.ease({
           scale_x: 1, scale_y: 1, duration: half,
@@ -122,9 +169,9 @@ class Overlay {
       case 'idle':
         this._label.text = ''; this._stopPulse(); this.hide(); break;
       case 'listening':
-        this._label.text = 'Слушаю…'; this._dot.add_style_class_name('listening'); this._startPulse(700); this.show(); break;
+        this._label.text = 'Слушаю…'; this._dot.add_style_class_name('listening'); this._startPulse(this._cfg.listeningPeriod); this.show(); break;
       case 'thinking':
-        this._label.text = 'Думаю…'; this._dot.add_style_class_name('thinking'); this._startPulse(1100); this.show(); break;
+        this._label.text = 'Думаю…'; this._dot.add_style_class_name('thinking'); this._startPulse(this._cfg.thinkingPeriod); this.show(); break;
       case 'error':
         this._label.text = 'Ошибка'; this._dot.add_style_class_name('error'); this._box.add_style_class_name('ai-overlay-error');
         this._stopPulse(); this.show(); this._box.opacity = 180;
@@ -162,43 +209,51 @@ class DBusController {
   enable() {
     log('[ai-overlay] dbus.enable');
     try {
-      if (Gio.DBusExportedObject?.wrapJSObject) {
-        const impl = {
-          SetState: (state) => { this._overlay.setState(state); },         // ничего не возвращаем
-          GetState: () => this._overlay.getState(),                         // вернуть СТРОКУ, не массив
-          Show: () => { this._overlay.show(); },                            // ничего не возвращаем
-          Hide: () => { this._overlay.hide(); },                            // ничего не возвращаем
-          Ping: () => 'ok',                                                 // вернуть СТРОКУ, не массив
-        };
-        this._exported = Gio.DBusExportedObject.wrapJSObject(IFACE_XML, impl);
-        this._exported.export(Gio.DBus.session, OBJ_PATH);
-        this._nameId = Gio.bus_own_name(Gio.BusType.SESSION, BUS_NAME, Gio.BusNameOwnerFlags.REPLACE, null, null, null);
-        log(`[ai-overlay] D-Bus exported as ${BUS_NAME}`);
-        return;
-      }
-      // Fallback (редко нужен)
-      const node = Gio.DBusNodeInfo.new_for_xml(IFACE_XML);
-      const iface = node.lookup_interface(IFACE);
-      const vtable = {
-        method_call: (conn, sender, path, ifaceName, method, params, inv) => {
-          try {
-            switch (method) {
-              case 'SetState': this._overlay.setState(params.deepUnpack()[0]); inv.return_value(null); break;
-              case 'GetState': inv.return_value(GLib.Variant.new_tuple(GLib.Variant.new_string(this._overlay.getState()))); break;
-              case 'Show': this._overlay.show(); inv.return_value(null); break;
-              case 'Hide': this._overlay.hide(); inv.return_value(null); break;
-              case 'Ping': inv.return_value(GLib.Variant.new_tuple(GLib.Variant.new_string('ok'))); break;
-              default: inv.return_dbus_error('org.freedesktop.DBus.Error.UnknownMethod','Unknown'); break;
+      const busAcquired = (conn) => {
+        this._conn = conn;
+        if (Gio.DBusExportedObject?.wrapJSObject) {
+          const impl = {
+            SetState: (state) => { this._overlay.setState(state); },
+            GetState: () => this._overlay.getState(),
+            Show: () => { this._overlay.show(); },
+            Hide: () => { this._overlay.hide(); },
+            Ping: () => 'ok',
+          };
+          this._exported = Gio.DBusExportedObject.wrapJSObject(IFACE_XML, impl);
+          this._exported.export(conn, OBJ_PATH);
+        } else {
+          const node = Gio.DBusNodeInfo.new_for_xml(IFACE_XML);
+          const iface = node.lookup_interface(IFACE);
+          const vtable = {
+            method_call: (conn, sender, path, ifaceName, method, params, inv) => {
+              try {
+                switch (method) {
+                  case 'SetState': this._overlay.setState(params.deepUnpack()[0]); inv.return_value(null); break;
+                  case 'GetState': inv.return_value(GLib.Variant.new_tuple(GLib.Variant.new_string(this._overlay.getState()))); break;
+                  case 'Show': this._overlay.show(); inv.return_value(null); break;
+                  case 'Hide': this._overlay.hide(); inv.return_value(null); break;
+                  case 'Ping': inv.return_value(GLib.Variant.new_tuple(GLib.Variant.new_string('ok'))); break;
+                  default: inv.return_dbus_error('org.freedesktop.DBus.Error.UnknownMethod','Unknown'); break;
+                }
+              } catch (e) { logError(e, '[ai-overlay] dbus method'); inv.return_dbus_error('org.example.AIOverlay.Error', String(e)); }
             }
-          } catch (e) { logError(e, '[ai-overlay] dbus method'); inv.return_dbus_error('org.example.AIOverlay.Error', String(e)); }
+          };
+          this._regId = conn.register_object(OBJ_PATH, iface, vtable);
         }
+        log(`[ai-overlay] D-Bus exported as ${BUS_NAME}`);
       };
+
       this._nameId = Gio.DBus.own_name(
-        Gio.BusType.SESSION, BUS_NAME, Gio.BusNameOwnerFlags.REPLACE,
-        conn => { this._conn = conn; this._regId = conn.register_object(OBJ_PATH, iface, vtable); log(`[ai-overlay] D-Bus exported (fallback) as ${BUS_NAME}`); },
-        null, (conn, name) => log(`[ai-overlay] name lost: ${name}`)
+        Gio.BusType.SESSION,
+        BUS_NAME,
+        Gio.BusNameOwnerFlags.REPLACE,
+        busAcquired,
+        null,
+        (conn, name) => log(`[ai-overlay] name lost: ${name}`)
       );
-    } catch (e) { logError(e, '[ai-overlay] dbus.enable error'); }
+    } catch (e) {
+      logError(e, '[ai-overlay] dbus.enable error');
+    }
   }
 
   disable() {
@@ -206,7 +261,8 @@ class DBusController {
     try {
       if (this._exported) { this._exported.unexport(); this._exported = null; }
       if (this._conn && this._regId) { this._conn.unregister_object(this._regId); this._regId = 0; }
-      if (this._nameId) { Gio.bus_unown_name?.(this._nameId); Gio.DBus.unown_name?.(this._nameId); this._nameId = 0; }
+      if (this._nameId) { Gio.DBus.unown_name(this._nameId); this._nameId = 0; }
+      this._conn = null;
     } catch (e) { logError(e, '[ai-overlay] dbus.disable error'); }
   }
 }
@@ -214,7 +270,8 @@ class DBusController {
 export default class AiOverlayExtension extends Extension {
   enable() {
     log('[ai-overlay] extension.enable');
-    this._overlay = new Overlay(); this._overlay.enable();
+    this._config = loadConfig(this.dir);
+    this._overlay = new Overlay(this._config); this._overlay.enable();
     this._dbus = new DBusController(this._overlay); this._dbus.enable();
   }
   disable() {


### PR DESCRIPTION
## Summary
- load config.json to customize overlay size, font, animation and position
- apply configuration for pulse speed/amplitude and screen placement
- export D-Bus API on the connection that owns the session bus name

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe0e42f50832689d54577644421bd